### PR TITLE
Forge 1.19.2 Test for Legacy and Modern 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ PRs and issues welcome! Feel free to let me know if you've found a workaround, o
 |                                | BungeeCord     | ---           | ---         | N/A    | BungeeForge 1.12.2 doesn't seem to work at the moment |
 | Forge 1.16.5-36.2.39           | Velocity (AMB) | ?             | ?           |        |                                                       |
 | Forge 1.18.2-40.2.10           | Velocity (AMB) | Yes (With BF) | N/A         | Yes (With PCF)|                                                |
-| Forge 1.19.2-43.3.2            | Velocity (AMB) | Yes (With BF) | N/A           | Yes (With PCF)|                                                |
+| Forge 1.19.2-43.3.2            | Velocity (AMB) | Yes (With BF) | N/A         | Yes (With PCF)|                                                |
 | Forge 1.19.3-44.1.23           | Velocity (AMB) | ?             | ?           | ?      |                                                       |
 | Forge 1.19.4-45.2.2            | Velocity (AMB) | ?             | ?           | ?      |                                                       |
 | Forge 1.20.1-47.2.1            | Velocity (AMB) | ?             | ?           | ?      |                                                       |

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ PRs and issues welcome! Feel free to let me know if you've found a workaround, o
 |                                | BungeeCord     | ?             | ?           | N/A    |                                                       |
 | Forge 1.12.2-14.23.5.2860      | Velocity       | ---           | ---         | N/A    | BungeeForge 1.12.2 doesn't seem to work at the moment |
 |                                | BungeeCord     | ---           | ---         | N/A    | BungeeForge 1.12.2 doesn't seem to work at the moment |
-| Forge 1.16.5-36.2.39           | Velocity (AMB) | ?             | ?           | ?      |                                                       |
-| Forge 1.18.2-40.2.10           | Velocity (AMB) | ?             | ?           | ?      |                                                       |
-| Forge 1.19.2-43.3.2            | Velocity (AMB) | ?             | ?           | ?      |                                                       |
+| Forge 1.16.5-36.2.39           | Velocity (AMB) | ?             | ?           |        |                                                       |
+| Forge 1.18.2-40.2.10           | Velocity (AMB) | Yes (With BF) | N/A         | Yes (With PCF)|                                                |
+| Forge 1.19.2-43.3.2            | Velocity (AMB) | Yes (With BF) | N/A           | Yes (With PCF)|                                                |
 | Forge 1.19.3-44.1.23           | Velocity (AMB) | ?             | ?           | ?      |                                                       |
 | Forge 1.19.4-45.2.2            | Velocity (AMB) | ?             | ?           | ?      |                                                       |
 | Forge 1.20.1-47.2.1            | Velocity (AMB) | ?             | ?           | ?      |                                                       |


### PR DESCRIPTION
No Program exist to knowledge to run bungeeguard on forge so n/a

But otherwise both BF and PCF will Allow capabilities with no issues on this version 